### PR TITLE
FIX: Mutate_AddConnection() for feedforward networks did not evenly d…

### DIFF
--- a/UnityNEAT/Assets/SharpNEAT/EvolutionAlgorithms/NeatEvolutionAlgorithm.cs
+++ b/UnityNEAT/Assets/SharpNEAT/EvolutionAlgorithms/NeatEvolutionAlgorithm.cs
@@ -761,6 +761,10 @@ namespace SharpNeat.EvolutionAlgorithms
 
             for(int i=0; i<specieCount; i++)
             {
+                // Shuffle the genomes; this ensures that genomes with equal fitness are randomly distributed amongst themselves, and therefore
+                // that the top N genomes chosen for selection and elitism isn't biased to an arbitrary set that happen to be at the front of a genome list.
+                // N.B. In github/colgreen/SharpNEAT this is done using SortUtils.SortUnstable() for improved performance.
+                Utilities.Shuffle(_specieList[i].GenomeList, _rng);
                 _specieList[i].GenomeList.Sort(GenomeFitnessComparer<TGenome>.Singleton);
                 minSize = Math.Min(minSize, _specieList[i].GenomeList.Count);
                 maxSize = Math.Max(maxSize, _specieList[i].GenomeList.Count);

--- a/UnityNEAT/Assets/SharpNEAT/Genomes/Neat/NeatGenome.cs
+++ b/UnityNEAT/Assets/SharpNEAT/Genomes/Neat/NeatGenome.cs
@@ -713,18 +713,18 @@ namespace SharpNeat.Genomes.Neat
                     // for acyclic nets (because that can prevent futrue conenctions from targeting the output if it would
                     // create a cycle).
                     int srcNeuronIdx = _genomeFactory.Rng.Next(inputBiasHiddenNeuronCount);
-                    if(srcNeuronIdx >= _inputAndBiasNeuronCount && srcNeuronIdx < _inputBiasOutputNeuronCount) {
+                    if(srcNeuronIdx >= _inputAndBiasNeuronCount) {
                         srcNeuronIdx += _outputNeuronCount;
                     }
 
                     // Valid target nodes are all hidden and output nodes.
+                    // ENHANCEMENT: Devise more efficient strategy. This can still select the same node as source and target (the cyclic conenction is tested for below). 
                     int tgtNeuronIdx = _inputAndBiasNeuronCount + _genomeFactory.Rng.Next(hiddenOutputNeuronCount-1);
-                    if(srcNeuronIdx == tgtNeuronIdx)  {
-                        if(++tgtNeuronIdx == neuronCount) {
-                            // Wrap around to first possible target neuron (first output).
-                            // ENHANCEMENT: Devise more efficient strategy. This can still select the same node as source and target (the cyclic conenction is tested for below). 
-                            tgtNeuronIdx = _inputAndBiasNeuronCount;
-                        }
+                    if(srcNeuronIdx == tgtNeuronIdx)
+                    {
+                        // The source neuron was selected. To ensure selections are evenly distributed across all valid targets, this
+                        // selection is substituted with the last possible node in the list of possibilities (the last output node).
+                        tgtNeuronIdx = neuronCount-1;
                     }
 
                     // Test if this connection already exists or is recurrent
@@ -1011,7 +1011,11 @@ namespace SharpNeat.Genomes.Neat
                     return;
                 }
 
-                // TODO: Review this approach.
+                // ENHANCEMENT: If the number of connections is large relative to the number of required mutations, or the 
+                // absolute number of connections is small then the current approach is OK. If however the number of required 
+                // mutations is large such that the probability of 'hitting' an unmutated connections is low as the loop progresses,
+                // then we should use a set of non-mutated conenctions that we removed mutated connectiosn from in each loop.
+                //
                 // The mutation loop. Here we pick an index at random and scan forward from that point
                 // for the first non-mutated gene. This prevents any gene from being mutated more than once without
                 // too much overhead.
@@ -1019,17 +1023,18 @@ namespace SharpNeat.Genomes.Neat
                 // possibility of getting stuck in the inner while loop forever, as well as preventing previously 
                 // mutated connections from being mutated again.
                 _connectionGeneList.ResetIsMutatedFlags();
-                for(int i=0; i<mutations; i++)
+                
+                int maxRetries = mutations * 5;
+                for(int i=0, retryCount=0; i<mutations && retryCount < maxRetries; i++)
                 {
                     // Pick an index at random.
                     int index = _genomeFactory.Rng.Next(connectionCount);
 
-                    // Scan forward and find the first non-mutated gene.
-                    while(_connectionGeneList[index].IsMutated)
-                    {   // Increment index. Wrap around back to the start if we go off the end.
-                        if(++index==connectionCount) {
-                            index=0; 
-                        }
+                    // Test if the connection has already been mutated.
+                    if(_connectionGeneList[index].IsMutated)
+                    {
+                        retryCount++;
+                        continue;
                     }
                     
                     // Mutate the gene at 'index'.

--- a/UnityNEAT/Assets/SharpNEAT/Utility/FastRandom.cs
+++ b/UnityNEAT/Assets/SharpNEAT/Utility/FastRandom.cs
@@ -120,8 +120,22 @@ namespace SharpNeat.Utility
         {
             // The only stipulation stated for the xorshift RNG is that at least one of
             // the seeds x,y,z,w is non-zero. We fulfill that requirement by only allowing
-            // resetting of the x seed
-            _x = (uint)seed;
+            // resetting of the x seed.
+
+            // The first random sample will be very closely related to the value of _x we set here. 
+            // Thus setting _x = seed will result in a close correlation between the bit patterns of the seed and
+            // the first random sample, therefore if the seed has a pattern (e.g. 1,2,3) then there will also be 
+            // a recognisable pattern across the first random samples.
+            //
+            // Such a strong correlation between the seed and the first random sample is an undesirable
+            // charactersitic of a RNG, therefore we significantly weaken any correlation by hashing the seed's bits. 
+            // This is achieved by multiplying the seed with four large primes each with bits distributed over the
+            // full length of a 32bit value, finally adding the results to give _x.
+            _x = (uint)(  (seed * 1431655781) 
+                        + (seed * 1183186591)
+                        + (seed * 622729787)
+                        + (seed * 338294347));
+
             _y = Y;
             _z = Z;
             _w = W;
@@ -206,7 +220,7 @@ namespace SharpNeat.Utility
         }
 
         /// <summary>
-        /// Generates a random double. Values returned are from 0.0 up to but not including 1.0.
+        /// Generates a random double. Values returned are over the range [0, 1). That is, inclusive of 0.0 and exclusive of 1.0.
         /// </summary>
         public double NextDouble()
         {   
@@ -346,6 +360,19 @@ namespace SharpNeat.Utility
             return (int)(0x7FFFFFFF&(_w=(_w^(_w>>19))^(t^(t>>8))));
         }
 
+        /// <summary>
+        /// Generates a random double. Values returned are over the range (0, 1). That is, exclusive of both 0.0 and 1.0.
+        /// </summary>
+        public double NextDoubleNonZero()
+        {
+            uint t = _x^(_x<<11);
+            _x=_y; _y=_z; _z=_w;
+
+            // See notes on NextDouble(). Here we generate a random value from 0 to 0x7f ff ff fe, and add one
+            // to generate a random value from 1 to 0x7f ff ff ff.
+            return REAL_UNIT_INT*(int)((0x7FFFFFFE&(_w=(_w^(_w>>19))^(t^(t>>8))))+1U); 
+        }
+
         // Buffer 32 bits in bitBuffer, return 1 at a time, keep track of how many have been returned
         // with bitMask.
         uint _bitBuffer;
@@ -396,7 +423,7 @@ namespace SharpNeat.Utility
                 return (byte)_byteBuffer;  // Note. Masking with 0xFF is unnecessary.
             }
             _byteBufferState >>= 1;
-            return (byte)(_byteBuffer >>=1);
+            return (byte)(_byteBuffer >>=8);
         }
 
         #endregion

--- a/UnityNEAT/Assets/SharpNEAT/Utility/ZigguratGaussianSampler.cs
+++ b/UnityNEAT/Assets/SharpNEAT/Utility/ZigguratGaussianSampler.cs
@@ -409,8 +409,9 @@ namespace SharpNeat.Utility
             double x, y;
             do
             {
-                x = -Math.Log(_rng.NextDouble()) / __R;
-                y = -Math.Log(_rng.NextDouble());
+                // Note. we use NextDoubleNonZero() because Log(0) returns NaN and will also tend to be a very slow execution path (when it occurs, which is rarely).
+                x = -Math.Log(_rng.NextDoubleNonZero()) / __R;
+                y = -Math.Log(_rng.NextDoubleNonZero());
             }
             while(y+y < x*x);
             return __R + x;


### PR DESCRIPTION
…istribute the selection of random source and target neurons. This could result in some neurons having zero probability.

FIX: Mutate_ConnectionWeights() did not evenly distribute the selection of connections to mutate.

FIX/ENHANCEMENT: Genome sorting now uses an unstable sort algorithm that randomly distributes the position of genomes of equal fitness. This removes the previous arbitrary selection of the top N genomes for elitism and selection. This might improve fostering and maintanining of genetic diversity.
