### PR TITLE
Low end feature

### DIFF
--- a/UnityNEAT/Assets/SharpNEAT/Core/UnityParallelListEvaluator.cs
+++ b/UnityNEAT/Assets/SharpNEAT/Core/UnityParallelListEvaluator.cs
@@ -81,12 +81,12 @@ namespace SharpNEAT.Core
                         //    fitnessDict.Add(phenome, new FitnessInfo[_optimizer.Trials]);
                         //}
                         Coroutiner.StartCoroutine(_phenomeEvaluator.Evaluate(phenome));
+                        curr_group_size++;
                         if(_optimizer.Group_Eval){
                             if(curr_group_size%_optimizer.Group_Size == 0){
                                 yield return new WaitForSeconds(_optimizer.TrialDuration);
                             }
                         }
-                        curr_group_size++;
                     }
                 }
 

--- a/UnityNEAT/Assets/SharpNEAT/Core/UnityParallelListEvaluator.cs
+++ b/UnityNEAT/Assets/SharpNEAT/Core/UnityParallelListEvaluator.cs
@@ -58,6 +58,7 @@ namespace SharpNEAT.Core
                 Utility.Log("Iteration " + (i + 1));                
                 _phenomeEvaluator.Reset();
                 dict = new Dictionary<TGenome, TPhenome>();
+                int curr_group_size = _optimizer.Group_Size;
                 foreach (TGenome genome in genomeList)
                 {
                     
@@ -80,8 +81,12 @@ namespace SharpNEAT.Core
                         //    fitnessDict.Add(phenome, new FitnessInfo[_optimizer.Trials]);
                         //}
                         Coroutiner.StartCoroutine(_phenomeEvaluator.Evaluate(phenome));
-
-
+                        if(_optimizer.Group_Eval){
+                            if(curr_group_size%_optimizer.Group_Size == 0){
+                                yield return new WaitForSeconds(_optimizer.TrialDuration);
+                            }
+                        }
+                        curr_group_size++;
                     }
                 }
 

--- a/UnityNEAT/Assets/SharpNEAT/Optimizer.cs
+++ b/UnityNEAT/Assets/SharpNEAT/Optimizer.cs
@@ -16,6 +16,8 @@ public class Optimizer : MonoBehaviour {
     public int Trials;
     public float TrialDuration;
     public float StoppingFitness;
+    public bool Group_Eval = false;
+    public int Group_Size = 0;
     bool EARunning;
     string popFileSavePath, champFileSavePath;
 


### PR DESCRIPTION
Added an option in the Optimizer to run the parallel evaluation in chunks/groups of the population (Group_Eval & Group_Size), essentially limiting the maximum number of genomes that are evaluated at a time.
I use this system on my laptop when I need to run bigger populations (due to complexity) and/or use CPU-heavy recursion (E.g. training against a MiniMax-algorithm).
